### PR TITLE
use GNU canonical install directory locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,15 @@
 # Therefore the minimum version is set to 2.8 but this is a "soft constraint"
 # Since this project uses Fortran source code, CMake >= 2.6 is probably a hard
 # constraint as that is when Fortran support was finalized in CMake.
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)
 PROJECT( XMDF )
 
 SET(CMAKE_COLOR_MAKEFILE ON)
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+#get GNU compliant install locations
+INCLUDE(GNUInstallDirs)
+
 
 # Default to a release build
 IF ( NOT CMAKE_BUILD_TYPE )
@@ -68,18 +72,18 @@ CONFIGURE_FILE(
 
 INSTALL(
   EXPORT XMDFLibraryDepends
-  DESTINATION "lib/cmake/XMDF-${XMDF_VERSION_STRING}"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/XMDF-${XMDF_VERSION_STRING}"
   COMPONENT dev
 )
 
 INSTALL(
   FILES "${XMDF_BINARY_DIR}/XMDFConfig.cmake"
-  DESTINATION "lib/cmake/XMDF-${XMDF_VERSION_STRING}"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/XMDF-${XMDF_VERSION_STRING}"
   COMPONENT dev
 )
 
 INSTALL(
   FILES "${XMDF_BINARY_DIR}/XMDFConfigVersion.cmake"
-  DESTINATION "lib/cmake/XMDF-${XMDF_VERSION_STRING}"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/XMDF-${XMDF_VERSION_STRING}"
   COMPONENT dev
 )

--- a/XMDFConfig.cmake.in
+++ b/XMDFConfig.cmake.in
@@ -5,7 +5,7 @@ SET(XMDF_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include/xmdf")
 
 # Contains a description of the XMDF library built by this project along with
 # any libraries that it depends on.
-INCLUDE("@CMAKE_INSTALL_PREFIX@/lib/cmake/XMDF-@XMDF_VERSION_STRING@/XMDFLibraryDepends.cmake")
+INCLUDE("@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/cmake/XMDF-@XMDF_VERSION_STRING@/XMDFLibraryDepends.cmake")
 
 # Including the file above creates the "xmdf" target in any CMake project that
 # includes this file. Therefore, we can just store the target as the library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,8 +57,8 @@ TARGET_LINK_LIBRARIES( xmdf ${HDF5_LIBRARIES} )
 # Also, export a description of this libray for use by other CMake scripts.
 INSTALL(
   TARGETS xmdf EXPORT XMDFLibraryDepends
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 
@@ -74,12 +74,12 @@ SET_TARGET_PROPERTIES( xmdf
 )
 INSTALL(
   DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran_modules/
-  DESTINATION include/xmdf
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xmdf
 )
 
 # Install C include files to prefix/include
 INSTALL(
   DIRECTORY
     ${XMDF_SOURCE_DIR}/include/xmdf
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
from cmake version 2.8.5 and above, GNUInstallDirs script is included,
which sets the values of CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_INCLUDEDIR
etc to canonical values on your system (e.g. /usr/local/lib64/), rather
than hardcoded "/lib/xmdf" that was there previously.
In addition, this makes packaging a lot more convenient on some distros
(notably openSuSE and fedora), whose %cmake RPM macro uses these variable
names to locate the installed files properly according to the distro
standard.
